### PR TITLE
fix(storybook): exclude colocateCss plugin and set base path for Pages (#3, #4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,3 +28,34 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  storybook-build:
+    name: Storybook Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - run: npm ci
+
+      - name: Build Storybook
+        run: npm run build-storybook
+
+      - name: Verify asset integrity
+        run: |
+          node -e "
+          const fs = require('fs');
+          const html = fs.readFileSync('storybook-static/iframe.html', 'utf8');
+          const assets = [...html.matchAll(/(?:href|src)=\"([^\"]+\.(css|js))\"/g)].map(m => m[1]);
+          let failed = false;
+          for (const a of assets) {
+            const p = 'storybook-static' + a;
+            if (!fs.existsSync(p)) { console.error('Missing asset:', p); failed = true; }
+          }
+          if (failed) process.exit(1);
+          console.log('All', assets.length, 'assets verified.');
+          "

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -27,8 +27,14 @@ jobs:
 
       - run: npm ci
 
+      - name: Configure Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
       - name: Build Storybook
         run: npm run build-storybook
+        env:
+          STORYBOOK_BASE_URL: ${{ steps.pages.outputs.base_path }}
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type { StorybookConfig } from '@storybook/react-vite'
+import type { InlineConfig, Plugin } from 'vite'
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.stories.@(ts|tsx)'],
@@ -12,6 +13,17 @@ const config: StorybookConfig = {
   },
   docs: {
     autodocs: 'tag',
+  },
+  async viteFinal(viteConfig: InlineConfig): Promise<InlineConfig> {
+    const flatPlugins = (viteConfig.plugins ?? []).flat(Infinity) as Plugin[]
+    const filteredPlugins = flatPlugins.filter(
+      (p): p is Plugin => Boolean(p) && (p as Plugin).name !== 'cobalt:colocate-css',
+    )
+    return {
+      ...viteConfig,
+      base: process.env['STORYBOOK_BASE_URL'] ?? '/',
+      plugins: filteredPlugins,
+    }
   },
 }
 


### PR DESCRIPTION
The cobalt:colocate-css Vite plugin (from vite.config.ts) was inherited by
Storybook's builder and renamed hashed preview CSS chunks, breaking the
<link rel="preload"> references in the generated HTML. Simultaneously, the
build had no base path configured, so asset URLs used the root-relative /
default instead of /design-system/ required by GitHub Pages.

viteFinal in .storybook/main.ts now strips the library-only plugin from the
plugin list and reads STORYBOOK_BASE_URL (set by configure-pages@v5 in CI)
to configure the correct base path. Local dev falls back to '/'.

Closes #3
Closes #4

https://claude.ai/code/session_01PCQMfx5DLzuwQrA9nF6ezJ