### PR TITLE
docs: Add GitHub PAT token configuration to npm setup

### DIFF
--- a/.changeset/fix-consumer-npmrc-docs.md
+++ b/.changeset/fix-consumer-npmrc-docs.md
@@ -1,0 +1,5 @@
+---
+"@q-labs/cobalt": patch
+---
+
+Add missing auth token line to consumer `.npmrc` install instructions in README.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Add to `.npmrc` in your project:
 
 ```
 @q-labs:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=YOUR_GITHUB_PAT
 ```
 
 Then install:

--- a/README.md
+++ b/README.md
@@ -12,14 +12,19 @@ Dark-first. Cobalt and crimson. Space Grotesk / DM Sans / JetBrains Mono.
 
 ## Install
 
-Add to `.npmrc` in your project:
+Add to your **user-level** `~/.npmrc` (not your project's repo-tracked `.npmrc` — keep the token out of source control):
+
+```
+//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}
+```
+
+Add to your **project** `.npmrc` (safe to commit — no secrets):
 
 ```
 @q-labs:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=YOUR_GITHUB_PAT
 ```
 
-Then install:
+Set `GITHUB_TOKEN` to a GitHub PAT with `read:packages` scope, or use your CI provider's built-in token. Then install:
 
 ```bash
 npm install @q-labs/cobalt


### PR DESCRIPTION
## Summary

Updates the README installation instructions to include the required `_authToken` configuration for authenticating with GitHub Packages. This is a necessary step for users to successfully install the `@q-labs` scoped package from the GitHub npm registry.

## Changes

- Added `//npm.pkg.github.com/:_authToken=YOUR_GITHUB_PAT` to the `.npmrc` configuration example
- This clarifies that users need to provide their GitHub Personal Access Token to authenticate with the registry

## Testing

No testing needed — documentation update only.

https://claude.ai/code/session_0182C3nM1mn21EZPY72fdLDv