### PR TITLE
Release v0.1.0: Initial Cobalt component library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,15 @@
 ### Patch Changes
 
 - c8f9011: Add missing auth token line to consumer `.npmrc` install instructions in README.
+
+## 0.1.0
+
+### Minor Changes
+
+- a196e32: Initial release of Cobalt — 43 React components across Typography, Atoms, Molecules, Organisms, and Templates. Includes a full CSS custom-property token system (cobalt + crimson palette, dark-first), 100% test coverage enforced via Vitest v8, Storybook 8 with play functions, dual ESM/CJS build via Vite lib mode, and GitHub Actions workflows for CI, Storybook Pages, README stats, and publishing.
+
+- 2f18611: Refactored the build to support per-component imports with colocated CSS. Added `gen-exports.mjs` and `build-css-bundle.mjs` scripts; updated `vite.config.ts` to emit individual entry points and a single `styles.css` bundle alongside each component's scoped stylesheet.
+
+- ad5edbe: Fixed Storybook deployment: excluded the `colocateCss` Vite plugin from the Storybook build and set the correct `base` path for GitHub Pages. Added CI workflow (`ci.yml`) and the Storybook publish workflow (`storybook.yml`).
+
+- 62cb2e3: Rebranded the package scope from `@qiheme/cobalt` to `@q-labs/cobalt`. Updated repository, homepage, and bugs URLs. Adopted Changesets for version management and publishing — added `@changesets/cli`, `.changeset/config.json`, and the `changeset.yml` GitHub Actions workflow that opens a Version PR on pending changesets and publishes to GitHub Packages when that PR merges.


### PR DESCRIPTION
## Summary

Initial release of Cobalt — a comprehensive React component library with 43 components across Typography, Atoms, Molecules, Organisms, and Templates. This release includes:

- **Component Library**: Full suite of 43 reusable React components with 100% test coverage
- **Design Tokens**: Complete CSS custom-property token system with cobalt + crimson palettes and dark-first theming
- **Build System**: Dual ESM/CJS output via Vite lib mode with per-component imports and colocated CSS
- **Testing**: Vitest v8 with enforced 100% branch coverage
- **Documentation**: Storybook 8 with play functions for interactive component stories
- **CI/CD**: GitHub Actions workflows for testing, Storybook deployment to GitHub Pages, README stats, and automated publishing
- **Package Management**: Migrated to Changesets for version management and publishing to GitHub Packages
- **Rebranding**: Updated package scope from `@qiheme/cobalt` to `@q-labs/cobalt`

## Key Changes

- **Build Architecture**: Added `gen-exports.mjs` and `build-css-bundle.mjs` scripts to support per-component entry points with individual scoped stylesheets and a unified `styles.css` bundle
- **Storybook Deployment**: Fixed GitHub Pages deployment by excluding `colocateCss` plugin from Storybook build and configuring correct base path
- **CI/CD Workflows**: Added `ci.yml` for automated testing and `storybook.yml` for Storybook publishing
- **Version Management**: Adopted Changesets with `.changeset/config.json` and `changeset.yml` workflow for automated versioning and GitHub Packages publishing
- **Package Scope**: Rebranded from `@qiheme/cobalt` to `@q-labs/cobalt` with updated repository metadata

## CI checks

- [x] `vitest run --coverage` passes at 100%
- [x] `tsc --noEmit` passes
- [x] `vite build` passes
- [x] Storybook builds without errors
- [x] GitHub Actions workflows configured and tested

https://claude.ai/code/session_01DbgxBiVLbWKSsjTzxtyi4o