### PR TITLE
docs: add Astro integration example with zero-JS smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,46 @@ export default function App() {
 
 ---
 
+## Using with Astro
+
+Cobalt works in [Astro](https://astro.build) with **zero client JavaScript**. Every component is purely presentational (no hooks, state, context, or browser APIs), so Astro server-renders them to static HTML — you only need an island (`client:*`) for genuinely interactive components.
+
+Install the React renderer alongside Cobalt:
+
+```bash
+npm install @q-labs/cobalt @astrojs/react react react-dom
+npx astro add react
+```
+
+Import the stylesheet once and set the theme on an HTML element — in `.astro` files you set `data-theme` directly instead of using `<CobaltProvider>`:
+
+```astro
+---
+// src/layouts/Base.astro
+import '@q-labs/cobalt/styles.css'
+---
+<html lang="en" data-theme="dark">
+  <body><slot /></body>
+</html>
+```
+
+Then use components in any `.astro` page. **With no `client:*` directive, Astro renders them to static HTML and ships no component JS:**
+
+```astro
+---
+import { Heading, Button, Badge, Card } from '@q-labs/cobalt'
+---
+<Card title="Status">
+  <Heading level={2}>Hello</Heading>
+  <Badge variant="active">Active</Badge>
+  <Button variant="primary">Get started</Button>
+</Card>
+```
+
+Reach for `<CobaltProvider>` only inside a React island that needs to override the theme for a hydrated subtree. A runnable proof-of-concept (with a `verify:zero-js` check) lives in [`examples/astro-smoke-test`](./examples/astro-smoke-test).
+
+---
+
 ## Components
 
 <!-- STATS:START -->

--- a/examples/astro-smoke-test/.gitignore
+++ b/examples/astro-smoke-test/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.astro/
+package-lock.json

--- a/examples/astro-smoke-test/README.md
+++ b/examples/astro-smoke-test/README.md
@@ -1,0 +1,49 @@
+# Cobalt × Astro — zero-JS smoke test
+
+Proves that `@q-labs/cobalt` renders to **static HTML with zero client
+JavaScript** inside an Astro site. Because every Cobalt component is purely
+presentational (no hooks, state, context, or browser APIs), Astro
+server-renders them and ships no component JS — no islands required.
+
+## What's here
+
+- `astro.config.mjs` — static output + `@astrojs/react` so React components
+  can be authored inside `.astro` pages.
+- `src/layouts/Base.astro` — imports `@q-labs/cobalt/styles.css` once and sets
+  `data-theme="dark"` on `<html>` (no `<CobaltProvider>` needed in `.astro`).
+- `src/pages/index.astro` — uses several Cobalt components with **no
+  `client:*` directive**.
+- `verify-zero-js.mjs` — asserts the build emitted zero `.js` files.
+
+## Run it
+
+This example depends on the local library via `file:../..`, so build the
+library first:
+
+```bash
+# from the repo root
+npm ci && npm run build
+
+# then, in this directory
+cd examples/astro-smoke-test
+npm install
+npm run build          # astro build → dist/
+npm run verify:zero-js # asserts no client JS was emitted
+```
+
+A passing run prints:
+
+```
+✓ Zero client JS shipped. 1 static HTML page(s) emitted.
+```
+
+## When you DO need an island
+
+If a future component becomes genuinely interactive (open/close state, focus
+management, etc.), hydrate only that one:
+
+```astro
+<MyInteractiveThing client:visible />
+```
+
+Everything else stays static.

--- a/examples/astro-smoke-test/astro.config.mjs
+++ b/examples/astro-smoke-test/astro.config.mjs
@@ -1,0 +1,10 @@
+import { defineConfig } from 'astro/config'
+import react from '@astrojs/react'
+
+// Static output. The React integration lets us author Cobalt's React
+// components inside .astro pages; without a `client:*` directive Astro
+// server-renders them to HTML and ships no component JS to the browser.
+export default defineConfig({
+  output: 'static',
+  integrations: [react()],
+})

--- a/examples/astro-smoke-test/package.json
+++ b/examples/astro-smoke-test/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "cobalt-astro-smoke-test",
+  "private": true,
+  "type": "module",
+  "version": "0.0.0",
+  "description": "Smoke test proving @q-labs/cobalt renders to static HTML with zero client JS in Astro.",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "verify:zero-js": "node verify-zero-js.mjs"
+  },
+  "dependencies": {
+    "@astrojs/react": "^4.2.0",
+    "@q-labs/cobalt": "file:../..",
+    "astro": "^5.6.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  }
+}

--- a/examples/astro-smoke-test/src/layouts/Base.astro
+++ b/examples/astro-smoke-test/src/layouts/Base.astro
@@ -1,0 +1,22 @@
+---
+// One global stylesheet for the whole site. `data-theme` on the element
+// drives all token values — no <CobaltProvider> needed in .astro files.
+import '@q-labs/cobalt/styles.css'
+
+interface Props {
+  title?: string
+}
+const { title = 'Cobalt × Astro' } = Astro.props
+---
+
+<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>

--- a/examples/astro-smoke-test/src/pages/index.astro
+++ b/examples/astro-smoke-test/src/pages/index.astro
@@ -1,0 +1,27 @@
+---
+// Cobalt React components used directly in an .astro page. No `client:*`
+// directive => Astro renders them to static HTML and ships zero JS.
+import Base from '../layouts/Base.astro'
+import { Heading, Body, Button, Badge, Card } from '@q-labs/cobalt'
+---
+
+<Base title="Cobalt × Astro — zero-JS smoke test">
+  <main style="max-width: 720px; margin: 0 auto; padding: 4rem 1.5rem;">
+    <Heading level={1}>Cobalt runs in Astro</Heading>
+    <Body variant="lg">
+      Every component below is server-rendered to static HTML. Open devtools
+      and check the network tab — no component JavaScript is loaded.
+    </Body>
+
+    <Card title="Status" meta="smoke test">
+      <Badge variant="active">Active</Badge>
+      <Badge variant="shipped">Shipped</Badge>
+      <Badge variant="wip">WIP</Badge>
+    </Card>
+
+    <p style="margin-top: 1.5rem;">
+      <Button variant="primary">Primary</Button>
+      <Button variant="ghost">Ghost</Button>
+    </p>
+  </main>
+</Base>

--- a/examples/astro-smoke-test/tsconfig.json
+++ b/examples/astro-smoke-test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react"
+  }
+}

--- a/examples/astro-smoke-test/verify-zero-js.mjs
+++ b/examples/astro-smoke-test/verify-zero-js.mjs
@@ -1,0 +1,52 @@
+// Asserts that the Astro build ships ZERO JavaScript to the browser.
+//
+// What matters is not whether a .js chunk exists on disk, but whether any
+// HTML page references one. With the React renderer installed, Astro emits an
+// unused React client chunk during its build phase, but because no page uses a
+// `client:*` directive, no <script> tag is ever written into the HTML — so the
+// browser downloads no JS. This script parses every built HTML file and fails
+// if any <script> tag is present.
+//
+// Run `npm run build` first, then `npm run verify:zero-js`.
+import { readdirSync, statSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const DIST = new URL('./dist/', import.meta.url).pathname
+
+function walk(dir) {
+  const out = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) out.push(...walk(full))
+    else out.push(full)
+  }
+  return out
+}
+
+let files
+try {
+  files = walk(DIST)
+} catch {
+  console.error('✗ No dist/ found. Run `npm run build` first.')
+  process.exit(1)
+}
+
+const htmlFiles = files.filter((f) => f.endsWith('.html'))
+if (htmlFiles.length === 0) {
+  console.error('✗ No HTML pages found in dist/. Did the build run?')
+  process.exit(1)
+}
+
+let failed = false
+for (const file of htmlFiles) {
+  const html = readFileSync(file, 'utf8')
+  const scripts = html.match(/<script\b[^>]*>/gi) ?? []
+  if (scripts.length > 0) {
+    failed = true
+    console.error(`✗ ${file.slice(DIST.length)} references ${scripts.length} <script> tag(s):`)
+    for (const s of scripts) console.error('  ' + s)
+  }
+}
+
+if (failed) process.exit(1)
+console.log(`✓ Zero client JS shipped. ${htmlFiles.length} static HTML page(s), no <script> tags.`)


### PR DESCRIPTION
## Summary

Adds a complete Astro integration example (`examples/astro-smoke-test`) demonstrating that Cobalt components render to **static HTML with zero client JavaScript** in Astro sites. Includes documentation in the main README explaining the integration pattern.

Because every Cobalt component is purely presentational (no hooks, state, context, or browser APIs), Astro server-renders them without needing islands. The example includes:

- **Astro project setup** with `@astrojs/react` and static output mode
- **Base layout** that imports the stylesheet once and sets `data-theme` on the root element (no `<CobaltProvider>` needed in `.astro` files)
- **Example page** using multiple Cobalt components with zero `client:*` directives
- **`verify-zero-js.mjs` script** that parses all built HTML and fails if any `<script>` tags are present — proving zero JS was shipped
- **README** with setup instructions and guidance on when to use islands for genuinely interactive components

Also updates the main README with a new "Using with Astro" section explaining the integration pattern and linking to the example.

## Test Plan

The smoke test is self-verifying:
1. `npm run build` produces static HTML
2. `npm run verify:zero-js` parses every `.html` file and asserts no `<script>` tags exist
3. If any script tag is found, the verification fails with a clear error message

This proves the integration works as intended — Cobalt components are server-rendered to static HTML with zero client JavaScript.

https://claude.ai/code/session_01KVQ5f6VZYDnrZkytSqwz9z