### PR TITLE
feat(tokens)!: rename primitives to drop --cobalt- namespace, add --gradient-brand

### DIFF
--- a/.changeset/rename-primitive-tokens.md
+++ b/.changeset/rename-primitive-tokens.md
@@ -1,0 +1,24 @@
+---
+"@q-labs/cobalt": minor
+---
+
+BREAKING: rename primitive CSS custom properties to drop the `--cobalt-` namespace so they match the Quincy OS design spec, and add a `--gradient-brand` token.
+
+Primitive renames (semantic tokens like `--bg-base`, `--text-primary`, `--accent-default` are unchanged):
+
+- `--cobalt-black-{50…950}` → `--black-{50…950}`
+- `--cobalt-blue-{50…950}` → `--cobalt-{50…950}`
+- `--cobalt-crimson-{50…900}` → `--crimson-{50…900}`
+- `--cobalt-silver-{50…900}` → `--silver-{50…900}`
+- `--cobalt-white` / `--cobalt-off-white` / `--cobalt-cream` → `--white` / `--off-white` / `--cream`
+- `--cobalt-font-*` → `--font-*`
+- `--cobalt-text-*` → `--text-*`
+- `--cobalt-weight-*` → `--weight-*`
+- `--cobalt-leading-*` → `--leading-*`
+- `--cobalt-tracking-*` → `--tracking-*`
+- `--cobalt-space-*` → `--space-*`
+- `--cobalt-radius-*` → `--radius-*`
+
+New: `--gradient-brand` is defined in both the dark and light token blocks.
+
+This is a breaking change for anyone referencing the old `--cobalt-*` primitive names directly. Released as a pre-1.0 minor bump.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,7 +23,7 @@ Always write the test file before the implementation. The test must fail first (
 - CSS Modules only — `import styles from './ComponentName.module.css'`
 - No inline `style={{}}` props
 - No hardcoded color/spacing values — always use `var(--token-name)`
-- Design tokens are in `src/tokens/index.css`, prefixed `--cobalt-*` for primitives and unprefixed for semantic tokens (`--bg-base`, `--text-primary`, `--accent-default`, etc.)
+- Design tokens are in `src/tokens/index.css`. Primitives use short scale names (`--cobalt-*`, `--black-*`, `--crimson-*`, `--silver-*`, `--space-*`, `--radius-*`, `--text-*`, etc.); semantic tokens are also unprefixed (`--bg-base`, `--text-primary`, `--accent-default`, etc.)
 - Dark mode is default on `:root`; light mode is `[data-theme="light"]`
 
 ## TypeScript rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ CI enforces 100% coverage. A PR cannot merge until all checks are green.
 
 - **CSS Modules only** — no inline styles, no Tailwind, no styled-components.
 - **All values use design tokens** — `var(--accent-default)` not `#2563EB`.
-- Token file: `src/tokens/index.css`. Primitive tokens are prefixed `--cobalt-*`. Semantic tokens are unprefixed (`--bg-base`, `--text-primary`, etc.).
+- Token file: `src/tokens/index.css`. Primitive tokens use short scale names (`--cobalt-*` for the blue/cobalt ramp, plus `--black-*`, `--crimson-*`, `--silver-*`, `--space-*`, `--radius-*`, `--text-*`, etc.). Semantic tokens are unprefixed (`--bg-base`, `--text-primary`, etc.).
 - Dark mode is the default (`:root`). Light mode overrides via `[data-theme="light"]`.
 - Use `CobaltProvider` or set `data-theme` on any ancestor element.
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Import tokens directly for custom integrations:
 @import '@q-labs/cobalt/tokens';
 ```
 
-Token categories: color primitives (`--cobalt-*`, `--crimson-*`), semantic colors (`--bg-base`, `--text-primary`, `--accent-default`), typography scale, spacing, border radius.
+Token categories: color primitives (`--cobalt-*`, `--black-*`, `--crimson-*`, `--silver-*`), semantic colors (`--bg-base`, `--text-primary`, `--accent-default`), typography scale, spacing, border radius.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@q-labs/cobalt",
-  "version": "0.2.0",
+  "version": "0.1.1",
   "description": "Cobalt — React component library for the Quincy OS design system by Cloud129 Technologies",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@q-labs/cobalt",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Cobalt — React component library for the Quincy OS design system by Cloud129 Technologies",
   "type": "module",
   "main": "./dist/cjs/index.cjs",

--- a/src/atoms/Avatar/Avatar.module.css
+++ b/src/atoms/Avatar/Avatar.module.css
@@ -2,11 +2,11 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: var(--cobalt-radius-full);
+  border-radius: var(--radius-full);
   background: var(--accent-subtle);
   color: var(--text-accent);
-  font-family: var(--cobalt-font-body);
-  font-weight: var(--cobalt-weight-semibold);
+  font-family: var(--font-body);
+  font-weight: var(--weight-semibold);
   overflow: hidden;
   flex-shrink: 0;
 }
@@ -20,17 +20,17 @@
 .avatar--sm {
   width: 28px;
   height: 28px;
-  font-size: var(--cobalt-text-2xs);
+  font-size: var(--text-2xs);
 }
 
 .avatar--md {
   width: 36px;
   height: 36px;
-  font-size: var(--cobalt-text-xs);
+  font-size: var(--text-xs);
 }
 
 .avatar--lg {
   width: 56px;
   height: 56px;
-  font-size: var(--cobalt-text-base);
+  font-size: var(--text-base);
 }

--- a/src/atoms/Badge/Badge.module.css
+++ b/src/atoms/Badge/Badge.module.css
@@ -1,12 +1,12 @@
 .badge {
   display: inline-flex;
   align-items: center;
-  gap: var(--cobalt-space-1);
-  font-family: var(--cobalt-font-body);
-  font-size: var(--cobalt-text-xs);
-  font-weight: var(--cobalt-weight-medium);
-  padding: 2px var(--cobalt-space-2);
-  border-radius: var(--cobalt-radius-full);
+  gap: var(--space-1);
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
+  padding: 2px var(--space-2);
+  border-radius: var(--radius-full);
   border: 1px solid transparent;
   white-space: nowrap;
 }

--- a/src/atoms/Button/Button.module.css
+++ b/src/atoms/Button/Button.module.css
@@ -2,10 +2,10 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: var(--cobalt-space-2);
-  font-family: var(--cobalt-font-body);
-  font-weight: var(--cobalt-weight-medium);
-  border-radius: var(--cobalt-radius-md);
+  gap: var(--space-2);
+  font-family: var(--font-body);
+  font-weight: var(--weight-medium);
+  border-radius: var(--radius-md);
   border: 1px solid transparent;
   cursor: pointer;
   text-decoration: none;
@@ -25,27 +25,27 @@
 
 /* Sizes */
 .btn--sm {
-  font-size: var(--cobalt-text-xs);
-  padding: var(--cobalt-space-1) var(--cobalt-space-3);
+  font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-3);
   height: 28px;
 }
 
 .btn--md {
-  font-size: var(--cobalt-text-sm);
-  padding: var(--cobalt-space-2) var(--cobalt-space-4);
+  font-size: var(--text-sm);
+  padding: var(--space-2) var(--space-4);
   height: 36px;
 }
 
 .btn--lg {
-  font-size: var(--cobalt-text-base);
-  padding: var(--cobalt-space-3) var(--cobalt-space-6);
+  font-size: var(--text-base);
+  padding: var(--space-3) var(--space-6);
   height: 44px;
 }
 
 /* Primary */
 .btn--primary {
   background: var(--accent-default);
-  color: var(--cobalt-white);
+  color: var(--white);
   border-color: var(--accent-default);
 }
 

--- a/src/atoms/Input/Input.module.css
+++ b/src/atoms/Input/Input.module.css
@@ -1,13 +1,13 @@
 .input {
   display: block;
   width: 100%;
-  font-family: var(--cobalt-font-body);
-  font-size: var(--cobalt-text-sm);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
   color: var(--text-primary);
   background: var(--bg-surface);
   border: 1px solid var(--border-default);
-  border-radius: var(--cobalt-radius-md);
-  padding: var(--cobalt-space-2) var(--cobalt-space-4);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-4);
   height: 40px;
   outline: none;
   transition: border-color 120ms ease, box-shadow 120ms ease;

--- a/src/atoms/NavBadge/NavBadge.module.css
+++ b/src/atoms/NavBadge/NavBadge.module.css
@@ -4,11 +4,11 @@
   justify-content: center;
   min-width: 18px;
   height: 18px;
-  padding: 0 var(--cobalt-space-1);
+  padding: 0 var(--space-1);
   background: var(--accent-default);
-  color: var(--cobalt-white);
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-2xs);
-  font-weight: var(--cobalt-weight-medium);
-  border-radius: var(--cobalt-radius-full);
+  color: var(--white);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-medium);
+  border-radius: var(--radius-full);
 }

--- a/src/atoms/ProgressBar/ProgressBar.module.css
+++ b/src/atoms/ProgressBar/ProgressBar.module.css
@@ -2,13 +2,13 @@
   width: 100%;
   height: 6px;
   background: var(--bg-raised);
-  border-radius: var(--cobalt-radius-full);
+  border-radius: var(--radius-full);
   overflow: hidden;
 }
 
 .fill {
   height: 100%;
-  border-radius: var(--cobalt-radius-full);
+  border-radius: var(--radius-full);
   transition: width 300ms ease;
 }
 

--- a/src/atoms/ProgressMini/ProgressMini.module.css
+++ b/src/atoms/ProgressMini/ProgressMini.module.css
@@ -2,7 +2,7 @@
   width: 60px;
   height: 3px;
   background: var(--bg-overlay);
-  border-radius: var(--cobalt-radius-full);
+  border-radius: var(--radius-full);
   overflow: hidden;
   flex-shrink: 0;
 }
@@ -10,6 +10,6 @@
 .fill {
   height: 100%;
   background: var(--accent-default);
-  border-radius: var(--cobalt-radius-full);
+  border-radius: var(--radius-full);
   transition: width 300ms ease;
 }

--- a/src/atoms/StatusDot/StatusDot.module.css
+++ b/src/atoms/StatusDot/StatusDot.module.css
@@ -2,7 +2,7 @@
   display: inline-block;
   width: 8px;
   height: 8px;
-  border-radius: var(--cobalt-radius-full);
+  border-radius: var(--radius-full);
   flex-shrink: 0;
 }
 

--- a/src/atoms/Tag/Tag.module.css
+++ b/src/atoms/Tag/Tag.module.css
@@ -1,14 +1,14 @@
 .tag {
   display: inline-flex;
   align-items: center;
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-2xs);
-  font-weight: var(--cobalt-weight-regular);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-regular);
   color: var(--text-tertiary);
   background: var(--bg-raised);
   border: 1px solid var(--border-subtle);
-  border-radius: var(--cobalt-radius-sm);
-  padding: 2px var(--cobalt-space-2);
+  border-radius: var(--radius-sm);
+  padding: 2px var(--space-2);
   white-space: nowrap;
-  letter-spacing: var(--cobalt-tracking-wide);
+  letter-spacing: var(--tracking-wide);
 }

--- a/src/molecules/ContactItem/ContactItem.module.css
+++ b/src/molecules/ContactItem/ContactItem.module.css
@@ -1,28 +1,28 @@
 .contact {
   display: flex;
   align-items: center;
-  gap: var(--cobalt-space-3);
+  gap: var(--space-3);
 }
 
 .icon {
   width: 24px;
   height: 24px;
-  border-radius: var(--cobalt-radius-sm);
+  border-radius: var(--radius-sm);
   background: var(--bg-raised);
   border: 1px solid var(--border-subtle);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-2xs);
-  font-weight: var(--cobalt-weight-semibold);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: var(--weight-semibold);
   color: var(--text-tertiary);
   flex-shrink: 0;
 }
 
 .value {
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-xs);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   color: var(--text-secondary);
   text-decoration: none;
 }

--- a/src/molecules/EducationEntry/EducationEntry.module.css
+++ b/src/molecules/EducationEntry/EducationEntry.module.css
@@ -2,28 +2,28 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: var(--cobalt-space-4);
-  padding: var(--cobalt-space-3) 0;
+  gap: var(--space-4);
+  padding: var(--space-3) 0;
   border-bottom: 1px solid var(--border-subtle);
 }
 
 .left { flex: 1; }
 
 .school {
-  font-size: var(--cobalt-text-sm);
-  font-weight: var(--cobalt-weight-semibold);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
   color: var(--text-primary);
 }
 
 .degree {
-  font-size: var(--cobalt-text-xs);
+  font-size: var(--text-xs);
   color: var(--text-secondary);
   margin-top: 2px;
 }
 
 .period {
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-xs);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   color: var(--text-tertiary);
   white-space: nowrap;
 }

--- a/src/molecules/ExperienceRole/ExperienceRole.module.css
+++ b/src/molecules/ExperienceRole/ExperienceRole.module.css
@@ -1,5 +1,5 @@
 .role {
-  padding: var(--cobalt-space-4) 0 var(--cobalt-space-4) var(--cobalt-space-4);
+  padding: var(--space-4) 0 var(--space-4) var(--space-4);
   border-left: 2px solid var(--border-subtle);
   position: relative;
 }
@@ -8,10 +8,10 @@
   content: '';
   position: absolute;
   left: -5px;
-  top: var(--cobalt-space-4);
+  top: var(--space-4);
   width: 8px;
   height: 8px;
-  border-radius: var(--cobalt-radius-full);
+  border-radius: var(--radius-full);
   background: var(--border-strong);
 }
 
@@ -24,19 +24,19 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: var(--cobalt-space-4);
-  margin-bottom: var(--cobalt-space-3);
+  gap: var(--space-4);
+  margin-bottom: var(--space-3);
 }
 
 .title {
-  font-size: var(--cobalt-text-sm);
-  font-weight: var(--cobalt-weight-semibold);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
   color: var(--text-primary);
 }
 
 .period {
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-xs);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   color: var(--text-tertiary);
   white-space: nowrap;
 }
@@ -44,10 +44,10 @@
 .bullets {
   list-style: none;
   padding: 0;
-  margin: 0 0 var(--cobalt-space-3);
+  margin: 0 0 var(--space-3);
   display: flex;
   flex-direction: column;
-  gap: var(--cobalt-space-2);
+  gap: var(--space-2);
 }
 
 .bullet::before {
@@ -56,14 +56,14 @@
 }
 
 .bullet {
-  font-size: var(--cobalt-text-xs);
+  font-size: var(--text-xs);
   color: var(--text-secondary);
-  line-height: var(--cobalt-leading-relaxed);
+  line-height: var(--leading-relaxed);
 }
 
 .tags {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--cobalt-space-1);
-  margin-top: var(--cobalt-space-2);
+  gap: var(--space-1);
+  margin-top: var(--space-2);
 }

--- a/src/molecules/MetricCard/MetricCard.module.css
+++ b/src/molecules/MetricCard/MetricCard.module.css
@@ -1,33 +1,33 @@
 .metric {
   display: flex;
   flex-direction: column;
-  gap: var(--cobalt-space-1);
-  padding: var(--cobalt-space-4);
+  gap: var(--space-1);
+  padding: var(--space-4);
   background: var(--bg-surface);
   border: 1px solid var(--border-subtle);
-  border-radius: var(--cobalt-radius-lg);
+  border-radius: var(--radius-lg);
 }
 
 .value {
-  font-family: var(--cobalt-font-display);
-  font-size: var(--cobalt-text-3xl);
-  font-weight: var(--cobalt-weight-bold);
-  line-height: var(--cobalt-leading-tight);
+  font-family: var(--font-display);
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-tight);
   color: var(--text-primary);
 }
 
 .label {
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-xs);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   color: var(--text-tertiary);
   text-transform: uppercase;
-  letter-spacing: var(--cobalt-tracking-wider);
+  letter-spacing: var(--tracking-wider);
 }
 
 .delta {
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-xs);
-  font-weight: var(--cobalt-weight-medium);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-medium);
 }
 
 .delta--up   { color: var(--status-active); }

--- a/src/molecules/MissionItem/MissionItem.module.css
+++ b/src/molecules/MissionItem/MissionItem.module.css
@@ -1,14 +1,14 @@
 .mission {
   display: flex;
   align-items: center;
-  gap: var(--cobalt-space-3);
-  padding: var(--cobalt-space-2) 0;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
 }
 
 .status {
   width: 8px;
   height: 8px;
-  border-radius: var(--cobalt-radius-full);
+  border-radius: var(--radius-full);
   flex-shrink: 0;
 }
 
@@ -19,20 +19,20 @@
 
 .name {
   flex: 1;
-  font-size: var(--cobalt-text-sm);
+  font-size: var(--text-sm);
   color: var(--text-primary);
-  font-weight: var(--cobalt-weight-medium);
+  font-weight: var(--weight-medium);
 }
 
 .progress-wrap {
   display: flex;
   align-items: center;
-  gap: var(--cobalt-space-2);
+  gap: var(--space-2);
 }
 
 .pct {
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-xs);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   color: var(--text-tertiary);
   width: 32px;
   text-align: right;

--- a/src/molecules/NavItem/NavItem.module.css
+++ b/src/molecules/NavItem/NavItem.module.css
@@ -1,14 +1,14 @@
 .nav-item {
   display: flex;
   align-items: center;
-  gap: var(--cobalt-space-3);
-  padding: var(--cobalt-space-2) var(--cobalt-space-3);
-  border-radius: var(--cobalt-radius-md);
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
   cursor: pointer;
   color: var(--text-secondary);
-  font-family: var(--cobalt-font-body);
-  font-size: var(--cobalt-text-sm);
-  font-weight: var(--cobalt-weight-medium);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
   transition: background 120ms ease, color 120ms ease;
   position: relative;
   user-select: none;
@@ -32,7 +32,7 @@
   bottom: 6px;
   width: 2px;
   background: var(--accent-default);
-  border-radius: var(--cobalt-radius-full);
+  border-radius: var(--radius-full);
 }
 
 .icon {

--- a/src/molecules/QuickStatRow/QuickStatRow.module.css
+++ b/src/molecules/QuickStatRow/QuickStatRow.module.css
@@ -2,17 +2,17 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: var(--cobalt-space-2) 0;
+  padding: var(--space-2) 0;
 }
 
 .label {
-  font-family: var(--cobalt-font-body);
-  font-size: var(--cobalt-text-xs);
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
   color: var(--text-tertiary);
 }
 
 .value {
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-xs);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   color: var(--text-primary);
 }

--- a/src/molecules/SignalItem/SignalItem.module.css
+++ b/src/molecules/SignalItem/SignalItem.module.css
@@ -1,14 +1,14 @@
 .signal {
   display: flex;
   align-items: flex-start;
-  gap: var(--cobalt-space-3);
-  padding: var(--cobalt-space-3) 0;
+  gap: var(--space-3);
+  padding: var(--space-3) 0;
 }
 
 .icon-wrap {
   width: 36px;
   height: 36px;
-  border-radius: var(--cobalt-radius-md);
+  border-radius: var(--radius-md);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -26,22 +26,22 @@
 }
 
 .title {
-  font-family: var(--cobalt-font-body);
-  font-size: var(--cobalt-text-sm);
-  font-weight: var(--cobalt-weight-medium);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
   color: var(--text-primary);
-  margin-bottom: var(--cobalt-space-1);
+  margin-bottom: var(--space-1);
 }
 
 .body {
-  font-family: var(--cobalt-font-body);
-  font-size: var(--cobalt-text-xs);
+  font-family: var(--font-body);
+  font-size: var(--text-xs);
   color: var(--text-secondary);
-  margin-bottom: var(--cobalt-space-1);
+  margin-bottom: var(--space-1);
 }
 
 .timestamp {
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-2xs);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
   color: var(--text-tertiary);
 }

--- a/src/molecules/SkillRow/SkillRow.module.css
+++ b/src/molecules/SkillRow/SkillRow.module.css
@@ -1,13 +1,13 @@
 .row {
   display: flex;
   align-items: center;
-  gap: var(--cobalt-space-3);
-  padding: var(--cobalt-space-2) 0;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
 }
 
 .name {
   flex: 1;
-  font-size: var(--cobalt-text-xs);
+  font-size: var(--text-xs);
   color: var(--text-secondary);
 }
 

--- a/src/molecules/StatItem/StatItem.module.css
+++ b/src/molecules/StatItem/StatItem.module.css
@@ -1,22 +1,22 @@
 .stat {
   display: flex;
   flex-direction: column;
-  gap: var(--cobalt-space-1);
-  padding: var(--cobalt-space-4) var(--cobalt-space-6);
+  gap: var(--space-1);
+  padding: var(--space-4) var(--space-6);
 }
 
 .value {
-  font-family: var(--cobalt-font-display);
-  font-size: var(--cobalt-text-4xl);
-  font-weight: var(--cobalt-weight-bold);
-  line-height: var(--cobalt-leading-tight);
+  font-family: var(--font-display);
+  font-size: var(--text-4xl);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-tight);
   color: var(--text-primary);
 }
 
 .label {
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-xs);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   color: var(--text-tertiary);
   text-transform: uppercase;
-  letter-spacing: var(--cobalt-tracking-wide);
+  letter-spacing: var(--tracking-wide);
 }

--- a/src/molecules/TimelineItem/TimelineItem.module.css
+++ b/src/molecules/TimelineItem/TimelineItem.module.css
@@ -1,6 +1,6 @@
 .timeline-item {
   display: flex;
-  gap: var(--cobalt-space-3);
+  gap: var(--space-3);
   position: relative;
 }
 
@@ -15,7 +15,7 @@
 .dot {
   width: 12px;
   height: 12px;
-  border-radius: var(--cobalt-radius-full);
+  border-radius: var(--radius-full);
   border: 2px solid var(--border-strong);
   background: var(--bg-surface);
   flex-shrink: 0;
@@ -32,25 +32,25 @@
   width: 1px;
   flex: 1;
   background: var(--border-subtle);
-  margin-top: var(--cobalt-space-1);
-  min-height: var(--cobalt-space-6);
+  margin-top: var(--space-1);
+  min-height: var(--space-6);
 }
 
 .content {
-  padding-bottom: var(--cobalt-space-4);
+  padding-bottom: var(--space-4);
   flex: 1;
 }
 
 .title {
-  font-family: var(--cobalt-font-body);
-  font-size: var(--cobalt-text-sm);
-  font-weight: var(--cobalt-weight-medium);
+  font-family: var(--font-body);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
   color: var(--text-primary);
 }
 
 .date {
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-xs);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   color: var(--text-tertiary);
-  margin-top: var(--cobalt-space-1);
+  margin-top: var(--space-1);
 }

--- a/src/molecules/UserBlock/UserBlock.module.css
+++ b/src/molecules/UserBlock/UserBlock.module.css
@@ -1,8 +1,8 @@
 .user-block {
   display: flex;
   align-items: center;
-  gap: var(--cobalt-space-3);
-  padding: var(--cobalt-space-3);
+  gap: var(--space-3);
+  padding: var(--space-3);
 }
 
 .info {
@@ -11,8 +11,8 @@
 }
 
 .name {
-  font-size: var(--cobalt-text-sm);
-  font-weight: var(--cobalt-weight-medium);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
   color: var(--text-primary);
   white-space: nowrap;
   overflow: hidden;
@@ -22,9 +22,9 @@
 .status {
   display: flex;
   align-items: center;
-  gap: var(--cobalt-space-1);
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-2xs);
+  gap: var(--space-1);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
   color: var(--text-tertiary);
   margin-top: 2px;
 }
@@ -32,6 +32,6 @@
 .dot {
   width: 6px;
   height: 6px;
-  border-radius: var(--cobalt-radius-full);
+  border-radius: var(--radius-full);
   background: var(--status-active);
 }

--- a/src/organisms/Card/Card.module.css
+++ b/src/organisms/Card/Card.module.css
@@ -1,7 +1,7 @@
 .card {
   background: var(--bg-surface);
   border: 1px solid var(--border-subtle);
-  border-radius: var(--cobalt-radius-lg);
+  border-radius: var(--radius-lg);
   overflow: hidden;
   transition: border-color 150ms ease, box-shadow 150ms ease;
 }
@@ -15,25 +15,25 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: var(--cobalt-space-4);
-  padding: var(--cobalt-space-4) var(--cobalt-space-4) 0;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-4) 0;
   border-bottom: 1px solid var(--border-subtle);
-  padding-bottom: var(--cobalt-space-3);
+  padding-bottom: var(--space-3);
 }
 
 .title {
-  font-family: var(--cobalt-font-display);
-  font-size: var(--cobalt-text-sm);
-  font-weight: var(--cobalt-weight-semibold);
+  font-family: var(--font-display);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
   color: var(--text-primary);
 }
 
 .meta {
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-xs);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   color: var(--text-tertiary);
 }
 
 .body {
-  padding: var(--cobalt-space-4);
+  padding: var(--space-4);
 }

--- a/src/organisms/ExperienceBlock/ExperienceBlock.module.css
+++ b/src/organisms/ExperienceBlock/ExperienceBlock.module.css
@@ -1,26 +1,26 @@
 .block {
-  margin-bottom: var(--cobalt-space-8);
+  margin-bottom: var(--space-8);
 }
 
 .header {
   display: flex;
   align-items: center;
-  gap: var(--cobalt-space-3);
-  margin-bottom: var(--cobalt-space-4);
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
 }
 
 .logo {
   width: 28px;
   height: 28px;
-  border-radius: var(--cobalt-radius-sm);
+  border-radius: var(--radius-sm);
   background: var(--bg-raised);
   border: 1px solid var(--border-subtle);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-xs);
-  font-weight: var(--cobalt-weight-bold);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
   color: var(--text-tertiary);
   flex-shrink: 0;
 }
@@ -28,14 +28,14 @@
 .org-info {}
 
 .org-name {
-  font-size: var(--cobalt-text-sm);
-  font-weight: var(--cobalt-weight-semibold);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
   color: var(--text-primary);
 }
 
 .tenure {
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-xs);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   color: var(--text-tertiary);
 }
 

--- a/src/organisms/FeatureCard/FeatureCard.module.css
+++ b/src/organisms/FeatureCard/FeatureCard.module.css
@@ -1,11 +1,11 @@
 .card {
   background: var(--bg-surface);
   border: 1px solid var(--border-subtle);
-  border-radius: var(--cobalt-radius-lg);
-  padding: var(--cobalt-space-6);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
   display: flex;
   flex-direction: column;
-  gap: var(--cobalt-space-4);
+  gap: var(--space-4);
   transition: border-color 150ms ease, transform 150ms ease, box-shadow 150ms ease;
 }
 
@@ -18,7 +18,7 @@
 .icon {
   width: 40px;
   height: 40px;
-  border-radius: var(--cobalt-radius-md);
+  border-radius: var(--radius-md);
   background: var(--accent-subtle);
   color: var(--text-accent);
   display: flex;
@@ -27,14 +27,14 @@
 }
 
 .title {
-  font-family: var(--cobalt-font-display);
-  font-size: var(--cobalt-text-base);
-  font-weight: var(--cobalt-weight-semibold);
+  font-family: var(--font-display);
+  font-size: var(--text-base);
+  font-weight: var(--weight-semibold);
   color: var(--text-primary);
 }
 
 .desc {
-  font-size: var(--cobalt-text-sm);
+  font-size: var(--text-sm);
   color: var(--text-secondary);
-  line-height: var(--cobalt-leading-relaxed);
+  line-height: var(--leading-relaxed);
 }

--- a/src/organisms/Hero/Hero.module.css
+++ b/src/organisms/Hero/Hero.module.css
@@ -1,5 +1,5 @@
 .hero {
-  padding: var(--cobalt-space-20) var(--cobalt-space-8);
+  padding: var(--space-20) var(--space-8);
   max-width: 680px;
   margin: 0 auto;
   text-align: center;
@@ -8,13 +8,13 @@
 .eyebrow {
   display: inline-flex;
   align-items: center;
-  gap: var(--cobalt-space-2);
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-xs);
+  gap: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   color: var(--text-tertiary);
-  letter-spacing: var(--cobalt-tracking-wider);
+  letter-spacing: var(--tracking-wider);
   text-transform: uppercase;
-  margin-bottom: var(--cobalt-space-4);
+  margin-bottom: var(--space-4);
 }
 
 .eyebrow::before {
@@ -26,20 +26,20 @@
 }
 
 .headline {
-  font-family: var(--cobalt-font-display);
-  font-size: clamp(var(--cobalt-text-4xl), 5vw, var(--cobalt-text-7xl));
-  font-weight: var(--cobalt-weight-bold);
-  line-height: var(--cobalt-leading-tight);
-  letter-spacing: var(--cobalt-tracking-tight);
+  font-family: var(--font-display);
+  font-size: clamp(var(--text-4xl), 5vw, var(--text-7xl));
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-tight);
+  letter-spacing: var(--tracking-tight);
   color: var(--text-primary);
-  margin: 0 0 var(--cobalt-space-6);
+  margin: 0 0 var(--space-6);
 }
 
 .sub {
-  font-size: var(--cobalt-text-lg);
+  font-size: var(--text-lg);
   color: var(--text-secondary);
-  line-height: var(--cobalt-leading-relaxed);
-  margin-bottom: var(--cobalt-space-8);
+  line-height: var(--leading-relaxed);
+  margin-bottom: var(--space-8);
 }
 
 .actions {
@@ -47,13 +47,13 @@
   align-items: center;
   justify-content: center;
   flex-wrap: wrap;
-  gap: var(--cobalt-space-3);
-  margin-bottom: var(--cobalt-space-8);
+  gap: var(--space-3);
+  margin-bottom: var(--space-8);
 }
 
 .meta {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: var(--cobalt-space-4);
+  gap: var(--space-4);
 }

--- a/src/organisms/ProjectCard/ProjectCard.module.css
+++ b/src/organisms/ProjectCard/ProjectCard.module.css
@@ -1,11 +1,11 @@
 .card {
   background: var(--bg-surface);
   border: 1px solid var(--border-subtle);
-  border-radius: var(--cobalt-radius-lg);
-  padding: var(--cobalt-space-4);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4);
   display: flex;
   flex-direction: column;
-  gap: var(--cobalt-space-3);
+  gap: var(--space-3);
   transition: border-color 150ms ease, box-shadow 150ms ease;
   position: relative;
   overflow: hidden;
@@ -20,13 +20,13 @@
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: var(--cobalt-space-3);
+  gap: var(--space-3);
 }
 
 .icon {
   width: 36px;
   height: 36px;
-  border-radius: var(--cobalt-radius-md);
+  border-radius: var(--radius-md);
   background: var(--bg-raised);
   border: 1px solid var(--border-subtle);
   display: flex;
@@ -36,36 +36,36 @@
 }
 
 .title {
-  font-family: var(--cobalt-font-display);
-  font-size: var(--cobalt-text-base);
-  font-weight: var(--cobalt-weight-semibold);
+  font-family: var(--font-display);
+  font-size: var(--text-base);
+  font-weight: var(--weight-semibold);
   color: var(--text-primary);
 }
 
 .description {
-  font-size: var(--cobalt-text-sm);
+  font-size: var(--text-sm);
   color: var(--text-secondary);
-  line-height: var(--cobalt-leading-relaxed);
+  line-height: var(--leading-relaxed);
 }
 
 .tags {
   display: flex;
   flex-wrap: wrap;
-  gap: var(--cobalt-space-1);
+  gap: var(--space-1);
 }
 
 .footer {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding-top: var(--cobalt-space-3);
+  padding-top: var(--space-3);
   border-top: 1px solid var(--border-subtle);
   margin-top: auto;
 }
 
 .link {
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-xs);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   color: var(--text-accent);
   text-decoration: none;
 }

--- a/src/organisms/Sidebar/Sidebar.module.css
+++ b/src/organisms/Sidebar/Sidebar.module.css
@@ -12,14 +12,14 @@
 }
 
 .logo-wrap {
-  padding: var(--cobalt-space-4) var(--cobalt-space-4) var(--cobalt-space-2);
+  padding: var(--space-4) var(--space-4) var(--space-2);
   border-bottom: 1px solid var(--border-subtle);
   flex-shrink: 0;
 }
 
 .nav {
   flex: 1;
-  padding: var(--cobalt-space-3) var(--cobalt-space-2);
+  padding: var(--space-3) var(--space-2);
   display: flex;
   flex-direction: column;
   gap: 2px;

--- a/src/organisms/StatusBar/StatusBar.module.css
+++ b/src/organisms/StatusBar/StatusBar.module.css
@@ -5,8 +5,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--cobalt-space-4);
-  padding: var(--cobalt-space-2) var(--cobalt-space-6);
+  gap: var(--space-4);
+  padding: var(--space-2) var(--space-6);
   background: var(--bg-surface);
   border-top: 1px solid var(--border-subtle);
 }
@@ -14,24 +14,24 @@
 .badge-wrap {
   display: flex;
   align-items: center;
-  gap: var(--cobalt-space-2);
+  gap: var(--space-2);
 }
 
 .dot {
   width: 6px;
   height: 6px;
-  border-radius: var(--cobalt-radius-full);
+  border-radius: var(--radius-full);
   background: var(--status-active);
 }
 
 .badge-text {
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-xs);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   color: var(--text-secondary);
 }
 
 .meta {
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-xs);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   color: var(--text-tertiary);
 }

--- a/src/organisms/TopNav/TopNav.module.css
+++ b/src/organisms/TopNav/TopNav.module.css
@@ -5,9 +5,9 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--cobalt-space-8);
+  gap: var(--space-8);
   height: 56px;
-  padding: 0 var(--cobalt-space-8);
+  padding: 0 var(--space-8);
   background: rgba(4, 5, 8, 0.85);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
@@ -23,7 +23,7 @@
 .links {
   display: flex;
   align-items: center;
-  gap: var(--cobalt-space-1);
+  gap: var(--space-1);
   flex: 1;
 }
 

--- a/src/organisms/Topbar/Topbar.module.css
+++ b/src/organisms/Topbar/Topbar.module.css
@@ -2,8 +2,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--cobalt-space-4);
-  padding: var(--cobalt-space-4) var(--cobalt-space-6);
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-6);
   border-bottom: 1px solid var(--border-subtle);
   background: var(--bg-surface);
   flex-shrink: 0;
@@ -12,20 +12,20 @@
 .left { display: flex; flex-direction: column; gap: 2px; }
 
 .title {
-  font-family: var(--cobalt-font-display);
-  font-size: var(--cobalt-text-lg);
-  font-weight: var(--cobalt-weight-semibold);
+  font-family: var(--font-display);
+  font-size: var(--text-lg);
+  font-weight: var(--weight-semibold);
   color: var(--text-primary);
 }
 
 .meta {
-  font-family: var(--cobalt-font-mono);
-  font-size: var(--cobalt-text-xs);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   color: var(--text-tertiary);
 }
 
 .actions {
   display: flex;
   align-items: center;
-  gap: var(--cobalt-space-2);
+  gap: var(--space-2);
 }

--- a/src/templates/DashboardLayout/DashboardLayout.module.css
+++ b/src/templates/DashboardLayout/DashboardLayout.module.css
@@ -15,5 +15,5 @@
 .content {
   flex: 1;
   overflow-y: auto;
-  padding: var(--cobalt-space-6);
+  padding: var(--space-6);
 }

--- a/src/templates/LandingLayout/LandingLayout.module.css
+++ b/src/templates/LandingLayout/LandingLayout.module.css
@@ -6,5 +6,5 @@
 .sections > * {
   max-width: 1080px;
   margin: 0 auto;
-  padding: var(--cobalt-space-16) var(--cobalt-space-8);
+  padding: var(--space-16) var(--space-8);
 }

--- a/src/templates/PortfolioLayout/PortfolioLayout.module.css
+++ b/src/templates/PortfolioLayout/PortfolioLayout.module.css
@@ -6,5 +6,5 @@
 .content {
   max-width: 1080px;
   margin: 0 auto;
-  padding: 0 var(--cobalt-space-8);
+  padding: 0 var(--space-8);
 }

--- a/src/templates/ResumeLayout/ResumeLayout.module.css
+++ b/src/templates/ResumeLayout/ResumeLayout.module.css
@@ -9,15 +9,15 @@
   flex: 1;
   display: grid;
   grid-template-columns: 260px 1fr;
-  gap: var(--cobalt-space-12);
+  gap: var(--space-12);
   max-width: 1040px;
   margin: 0 auto;
-  padding: var(--cobalt-space-10) var(--cobalt-space-8);
+  padding: var(--space-10) var(--space-8);
   width: 100%;
 }
 
 .sidebar {
   position: sticky;
-  top: var(--cobalt-space-10);
+  top: var(--space-10);
   align-self: start;
 }

--- a/src/tokens/index.css
+++ b/src/tokens/index.css
@@ -11,167 +11,167 @@
 
 :root {
   /* Charcoal / Near-Black */
-  --cobalt-black-50:  #F4F5F7;
-  --cobalt-black-100: #E5E7EC;
-  --cobalt-black-200: #C9CDD8;
-  --cobalt-black-300: #9AA0B0;
-  --cobalt-black-400: #6B7283;
-  --cobalt-black-500: #434959;
-  --cobalt-black-600: #282D3A;
-  --cobalt-black-700: #1A1E28;
-  --cobalt-black-800: #111318;
-  --cobalt-black-900: #080A0F;
-  --cobalt-black-950: #040508;
+  --black-50:  #F4F5F7;
+  --black-100: #E5E7EC;
+  --black-200: #C9CDD8;
+  --black-300: #9AA0B0;
+  --black-400: #6B7283;
+  --black-500: #434959;
+  --black-600: #282D3A;
+  --black-700: #1A1E28;
+  --black-800: #111318;
+  --black-900: #080A0F;
+  --black-950: #040508;
 
   /* Cobalt / Navy / Blue */
-  --cobalt-blue-50:  #EBF2FF;
-  --cobalt-blue-100: #BFDBFF;
-  --cobalt-blue-200: #93C1FF;
-  --cobalt-blue-300: #60A5FA;
-  --cobalt-blue-400: #3B82F6;
-  --cobalt-blue-500: #2563EB;
-  --cobalt-blue-600: #1D4ED8;
-  --cobalt-blue-700: #1E3A8A;
-  --cobalt-blue-800: #172756;
-  --cobalt-blue-900: #0F1A3D;
-  --cobalt-blue-950: #080E24;
+  --cobalt-50:  #EBF2FF;
+  --cobalt-100: #BFDBFF;
+  --cobalt-200: #93C1FF;
+  --cobalt-300: #60A5FA;
+  --cobalt-400: #3B82F6;
+  --cobalt-500: #2563EB;
+  --cobalt-600: #1D4ED8;
+  --cobalt-700: #1E3A8A;
+  --cobalt-800: #172756;
+  --cobalt-900: #0F1A3D;
+  --cobalt-950: #080E24;
 
   /* Crimson / Red */
-  --cobalt-crimson-50:  #FFF1F1;
-  --cobalt-crimson-100: #FFD9D9;
-  --cobalt-crimson-200: #FFAAAA;
-  --cobalt-crimson-300: #FF7070;
-  --cobalt-crimson-400: #F84B4B;
-  --cobalt-crimson-500: #EF2222;
-  --cobalt-crimson-600: #C41313;
-  --cobalt-crimson-700: #9A0E0E;
-  --cobalt-crimson-800: #6B0B0B;
-  --cobalt-crimson-900: #3D0606;
+  --crimson-50:  #FFF1F1;
+  --crimson-100: #FFD9D9;
+  --crimson-200: #FFAAAA;
+  --crimson-300: #FF7070;
+  --crimson-400: #F84B4B;
+  --crimson-500: #EF2222;
+  --crimson-600: #C41313;
+  --crimson-700: #9A0E0E;
+  --crimson-800: #6B0B0B;
+  --crimson-900: #3D0606;
 
   /* Silver / Metallic Neutrals */
-  --cobalt-silver-50:  #F8FAFC;
-  --cobalt-silver-100: #F1F5F9;
-  --cobalt-silver-200: #E2E8F0;
-  --cobalt-silver-300: #CBD5E1;
-  --cobalt-silver-400: #94A3B8;
-  --cobalt-silver-500: #64748B;
-  --cobalt-silver-600: #475569;
-  --cobalt-silver-700: #334155;
-  --cobalt-silver-800: #1E293B;
-  --cobalt-silver-900: #0F172A;
+  --silver-50:  #F8FAFC;
+  --silver-100: #F1F5F9;
+  --silver-200: #E2E8F0;
+  --silver-300: #CBD5E1;
+  --silver-400: #94A3B8;
+  --silver-500: #64748B;
+  --silver-600: #475569;
+  --silver-700: #334155;
+  --silver-800: #1E293B;
+  --silver-900: #0F172A;
 
   /* Off-white / Cream */
-  --cobalt-white:     #FFFFFF;
-  --cobalt-off-white: #F7F8FA;
-  --cobalt-cream:     #F0F2F5;
+  --white:     #FFFFFF;
+  --off-white: #F7F8FA;
+  --cream:     #F0F2F5;
 
   /* Font families */
-  --cobalt-font-display: 'Space Grotesk', 'Helvetica Neue', sans-serif;
-  --cobalt-font-body:    'DM Sans', 'Helvetica Neue', sans-serif;
-  --cobalt-font-mono:    'JetBrains Mono', 'Fira Code', monospace;
+  --font-display: 'Space Grotesk', 'Helvetica Neue', sans-serif;
+  --font-body:    'DM Sans', 'Helvetica Neue', sans-serif;
+  --font-mono:    'JetBrains Mono', 'Fira Code', monospace;
 
   /* Font sizes */
-  --cobalt-text-2xs:  0.625rem;
-  --cobalt-text-xs:   0.75rem;
-  --cobalt-text-sm:   0.875rem;
-  --cobalt-text-base: 1rem;
-  --cobalt-text-lg:   1.125rem;
-  --cobalt-text-xl:   1.25rem;
-  --cobalt-text-2xl:  1.5rem;
-  --cobalt-text-3xl:  1.875rem;
-  --cobalt-text-4xl:  2.25rem;
-  --cobalt-text-5xl:  3rem;
-  --cobalt-text-6xl:  3.75rem;
-  --cobalt-text-7xl:  4.5rem;
-  --cobalt-text-8xl:  6rem;
+  --text-2xs:  0.625rem;
+  --text-xs:   0.75rem;
+  --text-sm:   0.875rem;
+  --text-base: 1rem;
+  --text-lg:   1.125rem;
+  --text-xl:   1.25rem;
+  --text-2xl:  1.5rem;
+  --text-3xl:  1.875rem;
+  --text-4xl:  2.25rem;
+  --text-5xl:  3rem;
+  --text-6xl:  3.75rem;
+  --text-7xl:  4.5rem;
+  --text-8xl:  6rem;
 
   /* Font weights */
-  --cobalt-weight-light:    300;
-  --cobalt-weight-regular:  400;
-  --cobalt-weight-medium:   500;
-  --cobalt-weight-semibold: 600;
-  --cobalt-weight-bold:     700;
+  --weight-light:    300;
+  --weight-regular:  400;
+  --weight-medium:   500;
+  --weight-semibold: 600;
+  --weight-bold:     700;
 
   /* Line heights */
-  --cobalt-leading-tight:   1.15;
-  --cobalt-leading-snug:    1.3;
-  --cobalt-leading-normal:  1.5;
-  --cobalt-leading-relaxed: 1.65;
-  --cobalt-leading-loose:   1.8;
+  --leading-tight:   1.15;
+  --leading-snug:    1.3;
+  --leading-normal:  1.5;
+  --leading-relaxed: 1.65;
+  --leading-loose:   1.8;
 
   /* Letter spacing */
-  --cobalt-tracking-tighter: -0.04em;
-  --cobalt-tracking-tight:   -0.02em;
-  --cobalt-tracking-normal:   0em;
-  --cobalt-tracking-wide:     0.04em;
-  --cobalt-tracking-wider:    0.08em;
-  --cobalt-tracking-widest:   0.14em;
+  --tracking-tighter: -0.04em;
+  --tracking-tight:   -0.02em;
+  --tracking-normal:   0em;
+  --tracking-wide:     0.04em;
+  --tracking-wider:    0.08em;
+  --tracking-widest:   0.14em;
 
   /* Spacing */
-  --cobalt-space-1:  0.25rem;
-  --cobalt-space-2:  0.5rem;
-  --cobalt-space-3:  0.75rem;
-  --cobalt-space-4:  1rem;
-  --cobalt-space-5:  1.25rem;
-  --cobalt-space-6:  1.5rem;
-  --cobalt-space-8:  2rem;
-  --cobalt-space-10: 2.5rem;
-  --cobalt-space-12: 3rem;
-  --cobalt-space-16: 4rem;
-  --cobalt-space-20: 5rem;
-  --cobalt-space-24: 6rem;
-  --cobalt-space-32: 8rem;
+  --space-1:  0.25rem;
+  --space-2:  0.5rem;
+  --space-3:  0.75rem;
+  --space-4:  1rem;
+  --space-5:  1.25rem;
+  --space-6:  1.5rem;
+  --space-8:  2rem;
+  --space-10: 2.5rem;
+  --space-12: 3rem;
+  --space-16: 4rem;
+  --space-20: 5rem;
+  --space-24: 6rem;
+  --space-32: 8rem;
 
   /* Border radius */
-  --cobalt-radius-none: 0;
-  --cobalt-radius-xs:   2px;
-  --cobalt-radius-sm:   4px;
-  --cobalt-radius-md:   6px;
-  --cobalt-radius-lg:   10px;
-  --cobalt-radius-xl:   16px;
-  --cobalt-radius-2xl:  24px;
-  --cobalt-radius-full: 9999px;
+  --radius-none: 0;
+  --radius-xs:   2px;
+  --radius-sm:   4px;
+  --radius-md:   6px;
+  --radius-lg:   10px;
+  --radius-xl:   16px;
+  --radius-2xl:  24px;
+  --radius-full: 9999px;
 }
 
 /* ─── DARK MODE (default) ───────────────────────────────────────────────────── */
 
 :root,
 [data-theme="dark"] {
-  --bg-base:    var(--cobalt-black-950);
-  --bg-surface: var(--cobalt-black-900);
-  --bg-raised:  var(--cobalt-black-800);
-  --bg-overlay: var(--cobalt-black-700);
+  --bg-base:    var(--black-950);
+  --bg-surface: var(--black-900);
+  --bg-raised:  var(--black-800);
+  --bg-overlay: var(--black-700);
   --bg-sunken:  #030406;
 
   --border-subtle:  rgba(255, 255, 255, 0.05);
   --border-default: rgba(255, 255, 255, 0.09);
   --border-strong:  rgba(255, 255, 255, 0.15);
-  --border-accent:  var(--cobalt-blue-500);
+  --border-accent:  var(--cobalt-500);
 
   --text-primary:   #EEF0F5;
   --text-secondary: #8B95A8;
   --text-tertiary:  #556070;
   --text-disabled:  #394050;
-  --text-inverse:   var(--cobalt-black-950);
-  --text-accent:    var(--cobalt-blue-300);
-  --text-danger:    var(--cobalt-crimson-400);
+  --text-inverse:   var(--black-950);
+  --text-accent:    var(--cobalt-300);
+  --text-danger:    var(--crimson-400);
 
-  --accent-default: var(--cobalt-blue-500);
-  --accent-hover:   var(--cobalt-blue-400);
-  --accent-pressed: var(--cobalt-blue-600);
+  --accent-default: var(--cobalt-500);
+  --accent-hover:   var(--cobalt-400);
+  --accent-pressed: var(--cobalt-600);
   --accent-subtle:  rgba(37, 99, 235, 0.12);
   --accent-glow:    rgba(37, 99, 235, 0.25);
 
-  --danger-default: var(--cobalt-crimson-500);
-  --danger-hover:   var(--cobalt-crimson-400);
+  --danger-default: var(--crimson-500);
+  --danger-hover:   var(--crimson-400);
   --danger-subtle:  rgba(239, 34, 34, 0.12);
 
   --status-active:  #34D399;
   --status-warning: #FBBF24;
-  --status-danger:  var(--cobalt-crimson-400);
-  --status-info:    var(--cobalt-blue-300);
-  --status-neutral: var(--cobalt-silver-400);
-  --status-offline: var(--cobalt-black-400);
+  --status-danger:  var(--crimson-400);
+  --status-info:    var(--cobalt-300);
+  --status-neutral: var(--silver-400);
+  --status-offline: var(--black-400);
 
   --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.5);
   --shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.4), 0 1px 2px rgba(0, 0, 0, 0.6);
@@ -180,46 +180,48 @@
   --shadow-xl: 0 16px 64px rgba(0, 0, 0, 0.6), 0 8px 16px rgba(0, 0, 0, 0.4);
   --shadow-glow-cobalt:  0 0 24px rgba(37, 99, 235, 0.3);
   --shadow-glow-crimson: 0 0 24px rgba(239, 34, 34, 0.3);
+
+  --gradient-brand: linear-gradient(160deg, #0c1322, #060a12);
 }
 
 /* ─── LIGHT MODE ────────────────────────────────────────────────────────────── */
 
 [data-theme="light"] {
-  --bg-base:    var(--cobalt-off-white);
-  --bg-surface: var(--cobalt-white);
-  --bg-raised:  var(--cobalt-silver-100);
-  --bg-overlay: var(--cobalt-silver-200);
+  --bg-base:    var(--off-white);
+  --bg-surface: var(--white);
+  --bg-raised:  var(--silver-100);
+  --bg-overlay: var(--silver-200);
   --bg-sunken:  #ECEEF2;
 
   --border-subtle:  rgba(0, 0, 0, 0.04);
   --border-default: rgba(0, 0, 0, 0.08);
   --border-strong:  rgba(0, 0, 0, 0.14);
-  --border-accent:  var(--cobalt-blue-500);
+  --border-accent:  var(--cobalt-500);
 
   --text-primary:   #0D0F14;
   --text-secondary: #3D4A5C;
   --text-tertiary:  #6B7A90;
   --text-disabled:  #ACB5C4;
-  --text-inverse:   var(--cobalt-off-white);
-  --text-accent:    var(--cobalt-blue-600);
-  --text-danger:    var(--cobalt-crimson-600);
+  --text-inverse:   var(--off-white);
+  --text-accent:    var(--cobalt-600);
+  --text-danger:    var(--crimson-600);
 
-  --accent-default: var(--cobalt-blue-500);
-  --accent-hover:   var(--cobalt-blue-600);
-  --accent-pressed: var(--cobalt-blue-700);
+  --accent-default: var(--cobalt-500);
+  --accent-hover:   var(--cobalt-600);
+  --accent-pressed: var(--cobalt-700);
   --accent-subtle:  rgba(37, 99, 235, 0.08);
   --accent-glow:    rgba(37, 99, 235, 0.15);
 
-  --danger-default: var(--cobalt-crimson-600);
-  --danger-hover:   var(--cobalt-crimson-500);
+  --danger-default: var(--crimson-600);
+  --danger-hover:   var(--crimson-500);
   --danger-subtle:  rgba(196, 19, 19, 0.08);
 
   --status-active:  #059669;
   --status-warning: #D97706;
-  --status-danger:  var(--cobalt-crimson-600);
-  --status-info:    var(--cobalt-blue-500);
-  --status-neutral: var(--cobalt-silver-500);
-  --status-offline: var(--cobalt-silver-300);
+  --status-danger:  var(--crimson-600);
+  --status-info:    var(--cobalt-500);
+  --status-neutral: var(--silver-500);
+  --status-offline: var(--silver-300);
 
   --shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.06);
   --shadow-sm: 0 2px 6px rgba(0, 0, 0, 0.07), 0 1px 2px rgba(0, 0, 0, 0.05);
@@ -228,6 +230,8 @@
   --shadow-xl: 0 16px 64px rgba(0, 0, 0, 0.12), 0 8px 16px rgba(0, 0, 0, 0.08);
   --shadow-glow-cobalt:  0 0 24px rgba(37, 99, 235, 0.18);
   --shadow-glow-crimson: 0 0 24px rgba(196, 19, 19, 0.18);
+
+  --gradient-brand: linear-gradient(160deg, #f0f2f5, #e8eaf0);
 }
 
 /* ─── BASE RESET ────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Renames every **primitive** CSS custom property in `src/tokens/index.css` to drop the `--cobalt-` namespace, so the package source matches the Quincy OS design spec (`project/colors_and_type.css`) that consumers author against. The **semantic** tokens (the public component API — `--bg-base`, `--text-primary`, `--accent-default`, `--shadow-glow-cobalt`, …) are unchanged; only the inner `var(--cobalt-…)` references they resolve to were updated.

Because every primitive name changes, this is a **breaking** change. As the package is still pre-1.0 beta, it's released as a **minor** bump (`0.1.1` → `0.2.0`).

## Rename map (primitives only)

| Old | New |
|---|---|
| `--cobalt-black-{50…950}` | `--black-{50…950}` |
| `--cobalt-blue-{50…950}` | `--cobalt-{50…950}` |
| `--cobalt-crimson-{50…900}` | `--crimson-{50…900}` |
| `--cobalt-silver-{50…900}` | `--silver-{50…900}` |
| `--cobalt-white` / `--cobalt-off-white` / `--cobalt-cream` | `--white` / `--off-white` / `--cream` |
| `--cobalt-font-{display,body,mono}` | `--font-{…}` |
| `--cobalt-text-{2xs…8xl}` | `--text-{…}` |
| `--cobalt-weight-{light…bold}` | `--weight-{…}` |
| `--cobalt-leading-{tight…loose}` | `--leading-{…}` |
| `--cobalt-tracking-{tighter…widest}` | `--tracking-{…}` |
| `--cobalt-space-{1…32}` | `--space-{…}` |
| `--cobalt-radius-{none…full}` | `--radius-{…}` |

## Also in this PR

- **New token** `--gradient-brand` added to both the dark (`:root, [data-theme="dark"]`) and light (`[data-theme="light"]`) blocks:
  - Dark: `linear-gradient(160deg, #0c1322, #060a12)`
  - Light: `linear-gradient(160deg, #f0f2f5, #e8eaf0)`
- Renamed all `var(--cobalt-…)` references across **36 component CSS modules**.
- Updated docs that described the old prefix (`README.md`, `.github/copilot-instructions.md`, `CLAUDE.md`).
- Added a **minor** changeset and bumped `package.json` to `0.2.0`.

## Verification

- `npm run build` succeeds; verified `dist/esm/tokens/index.css` and `dist/cobalt.css` use the new short names, contain `--gradient-brand` (both themes), and have **zero** remaining old `--cobalt-{blue,black,crimson,silver,space,radius,text,font,weight,leading,tracking}-` prefixes.
- `npm run test:coverage` — **43 test files / 241 tests pass, 100% coverage** retained.
- Semantic tokens unchanged; `project/colors_and_type.css` (reference spec) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WRCD6xCaMYK1xMJpWmTCbM

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRCD6xCaMYK1xMJpWmTCbM)_